### PR TITLE
feat: implement featured post layout in ArticlePreview

### DIFF
--- a/src/components/ArticlePreview.tsx
+++ b/src/components/ArticlePreview.tsx
@@ -13,9 +13,10 @@ interface ArticlePreviewProps {
   post: NostrEvent;
   variant?: 'default' | 'compact';
   showAuthor?: boolean;
+  featured?: boolean;
 }
 
-export function ArticlePreview({ post, variant = 'default', showAuthor = true }: ArticlePreviewProps) {
+export function ArticlePreview({ post, variant = 'default', showAuthor = true, featured = false }: ArticlePreviewProps) {
   const { data: author } = useAuthor(post.pubkey);
   const metadata = author?.metadata;
 
@@ -43,14 +44,86 @@ export function ArticlePreview({ post, variant = 'default', showAuthor = true }:
   const avatarUrl = metadata?.picture;
 
   const isCompact = variant === 'compact';
-  const titleSize = isCompact ? 'text-lg' : 'text-xl sm:text-2xl';
-  const summaryLines = isCompact ? 'line-clamp-2' : 'line-clamp-3';
+  const titleSize = featured 
+    ? 'text-3xl sm:text-4xl' 
+    : isCompact 
+      ? 'text-lg' 
+      : 'text-xl sm:text-2xl';
+  const summaryLines = featured 
+    ? 'line-clamp-4' 
+    : isCompact 
+      ? 'line-clamp-2' 
+      : 'line-clamp-3';
   const dateFormat = isCompact
     ? { month: 'short', day: 'numeric', year: 'numeric' }
     : { year: 'numeric', month: 'long', day: 'numeric' };
 
   const valid = isValidDate(date);
 
+  // Featured layout - horizontal card with image on left
+  if (featured) {
+    return (
+      <Link to={`/${naddr}`}>
+        <Card className="overflow-hidden hover:shadow-xl transition-shadow">
+          <div className="grid md:grid-cols-2 gap-0">
+            {image && (
+              <div className="aspect-video md:aspect-auto overflow-hidden bg-muted">
+                <img
+                  src={image}
+                  alt={title}
+                  className="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
+                />
+              </div>
+            )}
+            <div className={`flex flex-col ${!image ? 'md:col-span-2' : ''}`}>
+              <CardHeader className="flex-1">
+                <h3 className={`${titleSize} font-bold line-clamp-2 mb-3`}>
+                  {title}
+                </h3>
+                {summary && (
+                  <p className={`text-muted-foreground ${summaryLines} text-base`}>
+                    {summary}
+                  </p>
+                )}
+              </CardHeader>
+              <CardContent className="pt-0">
+                {valid && (
+                  <div className={`flex items-center gap-2 text-sm text-muted-foreground ${showAuthor || hashtags.length > 0 ? 'mb-3' : ''}`}>
+                    <Calendar className="h-4 w-4" />
+                    <time dateTime={toISOStringSafe(date)}>
+                      {date.toLocaleDateString('en-US', dateFormat as Intl.DateTimeFormatOptions)}
+                    </time>
+                  </div>
+                )}
+                {showAuthor && (
+                  <div className={`flex items-center gap-2 ${hashtags.length > 0 ? 'mb-3' : ''}`}>
+                    <Avatar className="h-7 w-7">
+                      <AvatarImage src={avatarUrl} alt={displayName} />
+                      <AvatarFallback className="text-xs">
+                        {displayName.slice(0, 2).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="text-sm font-medium truncate">{displayName}</span>
+                  </div>
+                )}
+                {hashtags.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5">
+                    {hashtags.map((tag: string) => (
+                      <Badge key={tag} variant="secondary" className="text-xs">
+                        #{tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </div>
+          </div>
+        </Card>
+      </Link>
+    );
+  }
+
+  // Default layout - vertical card
   return (
     <Link to={`/${naddr}`}>
       <Card className="overflow-hidden hover:shadow-lg transition-shadow h-full flex flex-col">

--- a/src/components/LatestArticles.tsx
+++ b/src/components/LatestArticles.tsx
@@ -1,16 +1,15 @@
 import { useState } from 'react';
 import { Card, CardHeader } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Newspaper, ChevronDown } from 'lucide-react';
+import { Newspaper } from 'lucide-react';
 import { useLongFormContentNotes } from '@/hooks/useLongFormContentNotes';
 import { ArticlePreview } from '@/components/ArticlePreview';
 
-const INITIAL_POSTS_COUNT = 3;
-const LOAD_MORE_COUNT = 6;
+const INITIAL_POSTS_COUNT = 4;
+// const LOAD_MORE_COUNT = 6;
 
 export function LatestArticles() {
-  const [visibleCount, setVisibleCount] = useState(INITIAL_POSTS_COUNT);
+  const [visibleCount] = useState(INITIAL_POSTS_COUNT);
   const { data: posts, isLoading } = useLongFormContentNotes();
   
   // Loading state
@@ -45,11 +44,13 @@ export function LatestArticles() {
   }
   
   const visiblePosts = posts.slice(0, visibleCount);
-  const hasMore = visibleCount < posts.length;
+  // const hasMore = visibleCount < posts.length;
+  const featuredPost = visiblePosts[0];
+  const gridPosts = visiblePosts.slice(1, 4);
 
-  const handleLoadMore = () => {
-    setVisibleCount((prev) => Math.min(prev + LOAD_MORE_COUNT, posts.length));
-  };
+  // const handleLoadMore = () => {
+  //   setVisibleCount((prev) => Math.min(prev + LOAD_MORE_COUNT, posts.length));
+  // };
 
   return (
     <div className="space-y-6">
@@ -64,15 +65,24 @@ export function LatestArticles() {
         </div>
       </div>
 
-      {/* Posts Grid */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {visiblePosts.map((post) => (
-          <ArticlePreview key={post.id} post={post} />
-        ))}
-      </div>
+      {/* Featured Post - Full Width */}
+      {featuredPost && (
+        <div className="w-full">
+          <ArticlePreview key={featuredPost.id} post={featuredPost} featured />
+        </div>
+      )}
+
+      {/* Posts Grid - 3 articles */}
+      {gridPosts.length > 0 && (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {gridPosts.map((post) => (
+            <ArticlePreview key={post.id} post={post} />
+          ))}
+        </div>
+      )}
 
       {/* Load More Button */}
-      {hasMore && (
+      {/* {hasMore && (
         <div className="flex justify-center pt-4">
           <Button
             onClick={handleLoadMore}
@@ -87,7 +97,7 @@ export function LatestArticles() {
             </span>
           </Button>
         </div>
-      )}
+      )} */}
     </div>
   );
 }

--- a/src/components/LatestInHashtag.tsx
+++ b/src/components/LatestInHashtag.tsx
@@ -34,8 +34,6 @@ function validateBlogPost(event: NostrEvent): event is BlogPost {
   return true;
 }
 
-const INITIAL_POSTS_COUNT = 3;
-
 export function LatestInHashtag({ hashtags, icon, title }: LatestInHashtagProps) {
   const navigate = useNavigate();
   const { nostr } = useNostr();
@@ -111,8 +109,10 @@ export function LatestInHashtag({ hashtags, icon, title }: LatestInHashtagProps)
     return null;
   }
   
-  const visiblePosts = posts.slice(0, INITIAL_POSTS_COUNT);
-  const hasMore = posts.length > INITIAL_POSTS_COUNT;
+  const visiblePosts = posts.slice(0, 4);
+  const hasMore = posts.length > 4;
+  const featuredPost = visiblePosts[0];
+  const gridPosts = visiblePosts.slice(1, 4);
 
   return (
     <div className="space-y-6">
@@ -143,12 +143,21 @@ export function LatestInHashtag({ hashtags, icon, title }: LatestInHashtagProps)
         )}
       </div>
 
-      {/* Posts Grid */}
-      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {visiblePosts.map((post) => (
-          <ArticlePreview key={post.id} post={post} />
-        ))}
-      </div>
+      {/* Featured Post - Full Width */}
+      {featuredPost && (
+        <div className="w-full">
+          <ArticlePreview key={featuredPost.id} post={featuredPost} featured />
+        </div>
+      )}
+
+      {/* Posts Grid - 3 articles */}
+      {gridPosts.length > 0 && (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {gridPosts.map((post) => (
+            <ArticlePreview key={post.id} post={post} />
+          ))}
+        </div>
+      )}
 
     </div>
   );


### PR DESCRIPTION
This pull request introduces a "featured article" layout to the article preview and updates the display logic for lists of articles, both in the latest articles and hashtag-specific lists. The featured article is now shown in a prominent horizontal card at the top of the list, followed by a grid of three additional articles. These changes enhance the visual hierarchy and improve the user experience for browsing articles.

**Featured Article Layout**
- Added a `featured` prop to `ArticlePreview`, and implemented a horizontal card layout with larger title and summary for featured articles. The layout includes an image, author, date, and hashtags, and is conditionally rendered when `featured` is true. (`src/components/ArticlePreview.tsx`) [[1]](diffhunk://#diff-44fcad15ed83d22de0a5dc3a5241fc68c2783ba26cf6f3e6fb4596449c954bd0R16-R19) [[2]](diffhunk://#diff-44fcad15ed83d22de0a5dc3a5241fc68c2783ba26cf6f3e6fb4596449c954bd0L46-R126)

**Latest Articles List Display**
- Increased the initial number of visible articles from 3 to 4. The first article is now shown as featured, and the next three are displayed in a grid. Removed the "load more" button and related logic for simplicity. (`src/components/LatestArticles.tsx`) [[1]](diffhunk://#diff-4427b2c6364275d2a220a6d8fa23410bddd832eaa864a8b54dab7e835ae1248eL3-R12) [[2]](diffhunk://#diff-4427b2c6364275d2a220a6d8fa23410bddd832eaa864a8b54dab7e835ae1248eL48-R53) [[3]](diffhunk://#diff-4427b2c6364275d2a220a6d8fa23410bddd832eaa864a8b54dab7e835ae1248eL67-R85) [[4]](diffhunk://#diff-4427b2c6364275d2a220a6d8fa23410bddd832eaa864a8b54dab7e835ae1248eL90-R100)

**Hashtag Articles List Display**
- Updated hashtag-specific article lists to match the new featured/grid layout: show the first article as featured and the next three in a grid. Increased the initial visible count to 4. (`src/components/LatestInHashtag.tsx`) [[1]](diffhunk://#diff-d98a00b319cecc87162e74052e841ff18b1f9f1247153d4f853e7dbebac1ba64L37-L38) [[2]](diffhunk://#diff-d98a00b319cecc87162e74052e841ff18b1f9f1247153d4f853e7dbebac1ba64L114-R115) [[3]](diffhunk://#diff-d98a00b319cecc87162e74052e841ff18b1f9f1247153d4f853e7dbebac1ba64L146-R160)