### PR TITLE
feat: add ProfileSettingsModal

### DIFF
--- a/src/components/ProfileSettingsModal.tsx
+++ b/src/components/ProfileSettingsModal.tsx
@@ -1,0 +1,28 @@
+import { Settings } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { EditProfileForm } from '@/components/EditProfileForm';
+
+interface ProfileSettingsModalProps {
+  children?: React.ReactNode;
+}
+
+export function ProfileSettingsModal({ children }: ProfileSettingsModalProps) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        {children || (
+          <button className='flex items-center gap-2 p-2 rounded-md hover:bg-accent transition-colors w-full'>
+            <Settings className='w-4 h-4' />
+            <span>Profile Settings</span>
+          </button>
+        )}
+      </DialogTrigger>
+      <DialogContent className='max-w-2xl max-h-[85vh] overflow-y-auto'>
+        <DialogHeader>
+          <DialogTitle>Profile Settings</DialogTitle>
+        </DialogHeader>
+        <EditProfileForm />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/auth/AccountSwitcher.tsx
+++ b/src/components/auth/AccountSwitcher.tsx
@@ -1,7 +1,7 @@
 // NOTE: This file is stable and usually should not be modified.
 // It is important that all functionality in this file is preserved, and should only be modified if explicitly requested.
 
-import { ChevronDown, LogOut, UserIcon, UserPlus, Wallet } from 'lucide-react';
+import { ChevronDown, LogOut, Settings, UserIcon, UserPlus, Wallet } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar.tsx';
+import { ProfileSettingsModal } from '@/components/ProfileSettingsModal';
 import { WalletModal } from '@/components/WalletModal';
 import { useLoggedInAccounts, type Account } from '@/hooks/useLoggedInAccounts';
 import { genUserName } from '@/lib/genUserName';
@@ -77,6 +78,15 @@ export function AccountSwitcher({ onAddAccountClick }: AccountSwitcherProps) {
           </DropdownMenuItem>
         ))}
         <DropdownMenuSeparator />
+        <ProfileSettingsModal>
+          <DropdownMenuItem
+            className='flex items-center gap-2 cursor-pointer p-2 rounded-md'
+            onSelect={(e) => e.preventDefault()}
+          >
+            <Settings className='w-4 h-4' />
+            <span>Profile Settings</span>
+          </DropdownMenuItem>
+        </ProfileSettingsModal>
         <WalletModal>
           <DropdownMenuItem
             className='flex items-center gap-2 cursor-pointer p-2 rounded-md'


### PR DESCRIPTION
This pull request introduces a new profile settings modal and integrates it into the account switcher dropdown, providing users with a convenient way to access and edit their profile settings directly from the menu. The main changes are the creation of the `ProfileSettingsModal` component and its addition to the account switcher UI.

**New profile settings modal:**

* Added a new `ProfileSettingsModal` component that displays a dialog with the `EditProfileForm` for editing user profile settings (`src/components/ProfileSettingsModal.tsx`).

**Integration with account switcher:**

* Imported the new `ProfileSettingsModal` into the account switcher component (`src/components/auth/AccountSwitcher.tsx`).
* Added a "Profile Settings" menu item, wrapped with the `ProfileSettingsModal`, to the dropdown menu in the account switcher, allowing users to open the modal from the dropdown (`src/components/auth/AccountSwitcher.tsx`).
* Included the `Settings` icon in the account switcher imports and in the new menu item for visual consistency (`src/components/auth/AccountSwitcher.tsx`).